### PR TITLE
Fix a few issues creating examples from scratch

### DIFF
--- a/lib/cuke_modeler/example.rb
+++ b/lib/cuke_modeler/example.rb
@@ -53,8 +53,9 @@ module CukeModeler
             @parameters = row.keys
             @row_elements << Row.new("|#{row.keys.join('|')}|")
           end
-          @rows << row.each_value { |value| value.to_s.strip }
-          @row_elements << Row.new("|#{ordered_row_values(row).join('|')}|")
+          sanitized_row = row.inject({}) { |h, (k, v)| h[k] = v.to_s.strip; h }
+          @rows << sanitized_row
+          @row_elements << Row.new("|#{ordered_row_values(sanitized_row).join('|')}|")
         else
           raise(ArgumentError, "Can only add row from a Hash or an Array but received #{row.class}")
       end

--- a/lib/cuke_modeler/example.rb
+++ b/lib/cuke_modeler/example.rb
@@ -49,7 +49,10 @@ module CukeModeler
           @rows << Hash[@parameters.zip(row.collect { |value| value.to_s.strip })]
           @row_elements << Row.new("|#{row.join('|')}|")
         when row.is_a?(Hash)
-          @parameters = row.keys if @parameters.empty?
+          if @parameters.empty?
+            @parameters = row.keys
+            @row_elements << Row.new("|#{row.keys.join('|')}|")
+          end
           @rows << row.each_value { |value| value.to_s.strip }
           @row_elements << Row.new("|#{ordered_row_values(row).join('|')}|")
         else

--- a/lib/cuke_modeler/example.rb
+++ b/lib/cuke_modeler/example.rb
@@ -46,10 +46,11 @@ module CukeModeler
     def add_row(row)
       case
         when row.is_a?(Array)
-          @rows << Hash[@parameters.zip(row.collect { |value| value.strip })]
+          @rows << Hash[@parameters.zip(row.collect { |value| value.to_s.strip })]
           @row_elements << Row.new("|#{row.join('|')}|")
         when row.is_a?(Hash)
-          @rows << row.each_value { |value| value.strip! }
+          @parameters = row.keys if @parameters.empty?
+          @rows << row.each_value { |value| value.to_s.strip }
           @row_elements << Row.new("|#{ordered_row_values(row).join('|')}|")
         else
           raise(ArgumentError, "Can only add row from a Hash or an Array but received #{row.class}")
@@ -173,7 +174,7 @@ module CukeModeler
     end
 
     def string_for(cells, index)
-      cells[index] ? cells[index].ljust(determine_buffer_size(index)) : ''
+      cells[index] ? cells[index].to_s.ljust(determine_buffer_size(index)) : ''
     end
 
     def ordered_row_values(row_hash)


### PR DESCRIPTION
This PR corrects a few minor issues I encountered when creating examples from scratch.

1. When handing a hash to add_row, it was calling strip! on a frozen string.
2. When given non string values it would blow up.
3. When given a hash that used symbols instead of strings for keys it would blow up calling ljust.

There's one non-bugfix change included here on the hash path.  When handed a hash, use it's keys to populate the parameters array if that array is currently empty.