### PR TITLE
Add map_descendant, map_tree

### DIFF
--- a/lib/cuke_modeler/containing.rb
+++ b/lib/cuke_modeler/containing.rb
@@ -11,14 +11,24 @@ module CukeModeler
     # Executes the given code block with every model that is a child of this model.
     def each_descendant(&block)
       children.each do |child_model|
-        block.call(child_model)
-        child_model.each_descendant(&block) if child_model.respond_to?(:each_descendant)
+        next block.call(child_model) if child_model.children.empty?
+
+        child_model.each_descendant(&block)
+      end
+    end
+
+    # Executes and aggregates the return value of the given code block for each model that is a child of this model.
+    def map_descendant(&block)
+      children.map do |child_model|
+        next block.call(child_model) if child_model.children.empty?
+
+        child_model.map_descendant(&block)
       end
     end
 
     # Executes the given code block with this model and every model that is a child of this model.
     def each_model(&block)
-      block.call(self)
+      return block.call(self) if children.empty?
 
       each_descendant(&block)
     end

--- a/lib/cuke_modeler/containing.rb
+++ b/lib/cuke_modeler/containing.rb
@@ -23,7 +23,7 @@ module CukeModeler
         next block.call(child_model) if child_model.children.empty?
 
         child_model.map_descendant(&block)
-      end
+      end.flatten
     end
 
     # Executes the given code block with this model and every model that is a child of this model.
@@ -33,6 +33,17 @@ module CukeModeler
       each_descendant(&block)
     end
 
+    # Executes and aggregates the return value of the given code block for this and avery model that is a child of this model.
+    def map_model(&block)
+      children.map do |child_model|
+        next block.call(child_model) if child_model.children.empty?
+
+        [
+          block.call(self),
+          child_model.map_descendant(&block)
+        ]
+      end.flatten
+    end
 
     private
 

--- a/lib/cuke_modeler/containing.rb
+++ b/lib/cuke_modeler/containing.rb
@@ -34,7 +34,7 @@ module CukeModeler
     end
 
     # Executes and aggregates the return value of the given code block for this and avery model that is a child of this model.
-    def map_model(&block)
+    def map_tree(&block)
       children.map do |child_model|
         next block.call(child_model) if child_model.children.empty?
 

--- a/testing/rspec/spec/unit/shared/containing_models_unit_specs.rb
+++ b/testing/rspec/spec/unit/shared/containing_models_unit_specs.rb
@@ -81,7 +81,7 @@ shared_examples_for 'a containing model' do
     end
 
     it 'executes and aggregates the provided code on each model in its tree' do
-      names = parent_model.map_model do |model_node|
+      names = parent_model.map_tree do |model_node|
         model_node.name
       end
 
@@ -150,7 +150,7 @@ shared_examples_for 'a containing model' do
     end
 
     it 'executes and aggregates the provided code on each model in its tree' do
-      names = parent_model.map_model do |model_node|
+      names = parent_model.map_tree do |model_node|
         model_node.name
       end
 

--- a/testing/rspec/spec/unit/shared/containing_models_unit_specs.rb
+++ b/testing/rspec/spec/unit/shared/containing_models_unit_specs.rb
@@ -61,6 +61,15 @@ shared_examples_for 'a containing model' do
       expect(names).to be_empty
     end
 
+    it 'executes and aggregates the provided code on each descendant of the model' do
+      names = parent_model.map_descendant do |descendant_model|
+        descendant_model.name
+      end
+
+      expect(names).to be_empty
+    end
+
+
     it 'executes the provided code on each model in its tree' do
       names = []
 
@@ -109,6 +118,14 @@ shared_examples_for 'a containing model' do
 
       parent_model.each_descendant do |descendant_model|
         names << descendant_model.name
+      end
+
+      expect(names).to match_array(['child object 1', 'child object 2', 'grandchild object'])
+    end
+
+    it 'executes and aggregates the provided code on each descendant of the model' do
+      names = parent_model.map_descendant do |descendant_model|
+        descendant_model.name
       end
 
       expect(names).to match_array(['child object 1', 'child object 2', 'grandchild object'])

--- a/testing/rspec/spec/unit/shared/containing_models_unit_specs.rb
+++ b/testing/rspec/spec/unit/shared/containing_models_unit_specs.rb
@@ -80,6 +80,14 @@ shared_examples_for 'a containing model' do
       expect(names).to match_array(['top level model'])
     end
 
+    it 'executes and aggregates the provided code on each model in its tree' do
+      names = parent_model.map_model do |model_node|
+        model_node.name
+      end
+
+      expect(names).to match_array(['top level model'])
+    end
+
   end
 
 
@@ -136,6 +144,14 @@ shared_examples_for 'a containing model' do
 
       parent_model.each_model do |model_node|
         names << model_node.name
+      end
+
+      expect(names).to match_array(['top level model', 'child object 1', 'child object 2', 'grandchild object'])
+    end
+
+    it 'executes and aggregates the provided code on each model in its tree' do
+      names = parent_model.map_model do |model_node|
+        model_node.name
       end
 
       expect(names).to match_array(['top level model', 'child object 1', 'child object 2', 'grandchild object'])


### PR DESCRIPTION
The `each_descendant` and `each_model` methods are very convenient when parsing children of a `Containing` model.

In cases where aggregation of the block return value are desired, `.map` is often a more succinct way of achieving this.

This PR adds two new methods:

- `map_descendant`
- `map_tree`

Both methods do what you expect them to do. This allows for following example:

```ruby
      names = []

      parent_model.each_descendant do |descendant_model|
        names << descendant_model.name
      end
```

to be rewritten as

```ruby
      names = parent_model.map_descendant { |descendant_model| descendant_model.name }
```